### PR TITLE
Fixed call signature problem.

### DIFF
--- a/autosize.directive.ts
+++ b/autosize.directive.ts
@@ -8,7 +8,7 @@ export class AutosizeDirective implements AfterContentChecked {
   constructor(public element: ElementRef) {}
 
   @HostListener('input', ['$event.target'])
-  public onInput() {
+  public onInput(target) {
     this.resize();
   }
 


### PR DESCRIPTION
ngx-textarea-autosize works great during 'ng serve'. When building with 'ng build' it fails with:

> Supplied parameters do not match any signature of call target.

I was  a bit hard to debug, but finally, it turned out to be the host listerer. This change fixed the problem.
