### PR TITLE
Consider textarea border height when resizing

### DIFF
--- a/src/autosize.directive.ts
+++ b/src/autosize.directive.ts
@@ -25,9 +25,11 @@ export class AutosizeDirective implements AfterViewInit {
   @HostListener('input')
   private resize() {
     const textarea = this.elem.nativeElement as HTMLTextAreaElement;
+    // Calculate border height which is not included in scrollHeight
+    const borderHeight = textarea.offsetHeight - textarea.clientHeight;
     // Reset textarea height to auto that correctly calculate the new height
     textarea.style.height = 'auto';
     // Set new height
-    textarea.style.height = `${textarea.scrollHeight}px`;
+    textarea.style.height = `${textarea.scrollHeight + borderHeight}px`;
   }
 }


### PR DESCRIPTION
I noticed a 2px height difference while working on a view/edit toggle using ngx-textarea-autosize. In this view/edit UI a `div` element shows text and is swapped with a `textarea` with the same metrics when editing that text. 

The height difference was caused by setting the textarea's `height`, which in `border-box` sizing mode includes the border, to its `scrollHeight` which includes only the content inside the border. The pull request uses the well-supported [`offsetHeight`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetHeight) and [`clientHeight`](https://developer.mozilla.org/en-US/docs/Web/API/Element/clientHeight) properties to calculate the border size.

### Before
The textarea is 2 pixels shorter than its div counterpart. This is difficult to see, but the exaggerated example below makes the problem more obvious.

![border-bad](https://user-images.githubusercontent.com/507058/41788497-bdb13186-7619-11e8-9034-299b2ceab0ff.gif) 

### After
![border-good](https://user-images.githubusercontent.com/507058/41788498-bdbf343e-7619-11e8-812e-e7ad3e4e95cf.gif)

### Before (exaggerated border)
An exaggerated border makes this much easier to see, in this case the entire third line of text is not visible with auto resizing.

![absurd-bad](https://user-images.githubusercontent.com/507058/41788571-008e6c26-761a-11e8-8fe2-c1e94fd6abc4.gif) 

### After (exaggerated border)
![absurd-good](https://user-images.githubusercontent.com/507058/41788572-009d704a-761a-11e8-9e41-8b4bcbdf8bee.gif)
