### PR TITLE
make resize HostListener public

### DIFF
--- a/lib/src/autosize.directive.ts
+++ b/lib/src/autosize.directive.ts
@@ -31,7 +31,7 @@ export class AutosizeDirective implements AfterViewInit, DoCheck {
   }
 
   @HostListener('input')
-  private resize() {
+  public resize() {
     const textarea = this.elem.nativeElement as HTMLTextAreaElement;
     // Calculate border height which is not included in scrollHeight
     const borderHeight = textarea.offsetHeight - textarea.clientHeight;


### PR DESCRIPTION
This fixes the following error when using `fullTemplateTypeCheck: true` in `angularCompilerOptions` (default with Angular 8.1):

> Property 'resize' is private and only accessible within class 'AutosizeDirective'.