### PR TITLE
Update autosize.directive.ts to support for Angular 9.1

### DIFF
--- a/lib/src/autosize.directive.ts
+++ b/lib/src/autosize.directive.ts
@@ -31,7 +31,7 @@ export class AutosizeDirective implements AfterViewInit, DoCheck {
   }
 
   @HostListener('input')
-  private resize() {
+  public resize() {
     const textarea = this.elem.nativeElement as HTMLTextAreaElement;
     // Calculate border height which is not included in scrollHeight
     const borderHeight = textarea.offsetHeight - textarea.clientHeight;


### PR DESCRIPTION
Replaced private keyword with public as 9.1 update doesn't allow to access private variables outside that component but for this package it is mandate.